### PR TITLE
Add dependabot to repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This bot checks daily whether or not there are new versions of individual GitHub actions available and drafts pull requests to bump the version.