### PR TITLE
Fix colors piracy

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,3 +3,6 @@ ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GridVisualizeTools = "5573ae12-3b76-41d9-b48c-81d0b6e61cc5"
+
+[compat]
+Colors = "0.13"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, GridVisualizeTools, ColorTypes
+using Documenter, GridVisualizeTools, ColorTypes, Colors
 
 function mkdocs()
     DocMeta.setdocmeta!(GridVisualizeTools, :DocTestSetup, :(using GridVisualizeTools, ColorTypes, Colors); recursive = true)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,18 +36,6 @@ rgbtuple(:red)
 (1.0,1.0,1.0)
 ```
 
-```@docs
-ColorTypes.RGB
-```
-
-```@example
-using ColorTypes,GridVisualizeTools # hide
-RGB(:red)
-```
-```@example
-using ColorTypes,GridVisualizeTools # hide
-RGB("green")
-```
 
 ## Visibility handling of grid cells
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,7 +33,23 @@ rgbtuple
 rgbtuple(:red)
 # output
 
-(1.0,1.0,1.0)
+(1.0,0.0,0.0)
+```
+```@docs
+rgbcolor
+```
+
+```@jldoctest
+rgbcolor(:red)
+# output
+
+RGB{Float64}(1.0,0.0,0.0)
+```
+```@jldoctest
+rgbcolor(1.0, 0.0, 0.0)
+# output
+
+RGB{Float64}(1.0,0.0,0.0)
 ```
 
 

--- a/src/GridVisualizeTools.jl
+++ b/src/GridVisualizeTools.jl
@@ -7,7 +7,7 @@ using DocStringExtensions: SIGNATURES, TYPEDEF, TYPEDSIGNATURES
 using StaticArraysCore: SVector
 
 include("colors.jl")
-export region_cmap, bregion_cmap, rgbtuple
+export region_cmap, bregion_cmap, rgbtuple, rgbcolor
 
 include("extraction.jl")
 export extract_visible_cells3D, extract_visible_bfaces3D

--- a/src/colors.jl
+++ b/src/colors.jl
@@ -1,4 +1,4 @@
-"""
+"""depend
 $(SIGNATURES)
 
 Create customized distinguishable colormap for interior regions.
@@ -16,7 +16,9 @@ RGB{Float64}(0.85, 0.6, 0.6)
 """
 function region_cmap(n)
     ColorSchemes.distinguishable_colors(max(5, n),
-                                        [Colors.RGB(0.85, 0.6, 0.6), Colors.RGB(0.6, 0.85, 0.6), Colors.RGB(0.6, 0.6, 0.85)];
+                                        [Colors.RGB{Float64}(0.85, 0.6, 0.6), 
+                                         Colors.RGB{Float64}(0.6, 0.85, 0.6), 
+                                         Colors.RGB{Float64}(0.6, 0.6, 0.85)];
                                         lchoices = range(70; stop = 80, length = 5),
                                         cchoices = range(25; stop = 65, length = 15),
                                         hchoices = range(20; stop = 360, length = 15))
@@ -39,53 +41,15 @@ RGB{Float64}(1.0, 0.0, 0.0)
 """
 function bregion_cmap(n)
     ColorSchemes.distinguishable_colors(max(5, n),
-                                        [Colors.RGB(1.0, 0.0, 0.0), Colors.RGB(0.0, 1.0, 0.0), Colors.RGB(0.0, 0.0, 1.0)];
+                                        [Colors.RGB{Float64}(1.0, 0.0, 0.0), 
+                                         Colors.RGB{Float64}(0.0, 1.0, 0.0), 
+                                         Colors.RGB{Float64}(0.0, 0.0, 1.0)];
                                         lchoices = range(50; stop = 75, length = 10),
                                         cchoices = range(75; stop = 100, length = 10),
                                         hchoices = range(20; stop = 360, length = 30))
 end
 
 """
-$(SIGNATURES)
-
-Create RGB color from color name string.
-
-julia> Colors.RGB("red")
-RGB{Float64}(1.0,0.0,0.0)
-```
-"""
-function Colors.RGB(c::String)
-    c64 = Colors.color_names[c]
-    Colors.RGB(c64[1] / 255, c64[2] / 255, c64[3] / 255)
-end
-
-"""
-$(SIGNATURES)
-
-Create RGB color from color name symbol.
-
-```jldoctest
-julia> Colors.RGB(:red)
-RGB{Float64}(1.0, 0.0, 0.0)
-```
-"""
-Colors.RGB(c::Symbol) = Colors.RGB(String(c))
-
-"""
-$(SIGNATURES)
-
-Create RGB color from tuple
-
-```jldoctest
-julia> Colors.RGB((1.0,0,0))
-RGB{Float64}(1.0, 0.0, 0.0)
-```
-"""
-Colors.RGB(c::Tuple) = Colors.RGB(c...)
-
-"""
-$(SIGNATURES)
-
 Create color tuple from  color description (e.g. string)
 
 ```jldoctest
@@ -96,7 +60,7 @@ julia> rgbtuple("red")
 (1.0, 0.0, 0.0)
 ```
 """
-rgbtuple(c) = rgbtuple(Colors.RGB(c))
+rgbtuple(c) = rgbtuple(parse(Colors.RGB{Float64},c))
 
 """
 $(SIGNATURES)

--- a/src/colors.jl
+++ b/src/colors.jl
@@ -73,3 +73,53 @@ julia> rgbtuple(RGB(0.0,1,0))
 ```
 """
 rgbtuple(c::Colors.RGB) = (Colors.red(c), Colors.green(c), Colors.blue(c))
+
+
+"""
+    rgbcolor(col::Any)
+
+Return Colors.RGB object from string or symbol. 
+
+```jldoctest
+julia> rgbcolor(:red)
+RGB{Float64}(1.0, 0.0, 0.0)
+
+julia> rgbcolor("red")
+RGB{Float64}(1.0, 0.0, 0.0)
+```
+
+"""
+rgbcolor(col::Any) = parse(Colors.RGB{Float64},col) 
+
+
+"""
+    rgbcolor(col::RGB)
+
+Pass through of RGB color object.
+```jldoctest
+julia> rgbcolor(RGB(1.0,0.0, 0.0))
+RGB{Float64}(1.0, 0.0, 0.0)
+```
+
+"""
+rgbcolor(col::Colors.RGB) = col
+
+"""
+    rgbcolor(col::Tuple)
+
+Create RGB color object from tuple
+```jldoctest
+julia> rgbcolor((1.0,0.0, 0.0))
+RGB{Float64}(1.0, 0.0, 0.0)
+```
+
+"""
+function rgbcolor(col::Tuple)
+    # Base.depwarn(
+    #     "Setting custom colors as `Tuple`, e.g. `color=(0.,0.,1.)` will be removed in the next major release. "*
+    #     "Please use color=RGB(0.,0.,1.) instead.",
+    #     :update_lines,
+    # )
+    return Colors.RGB(col...)
+end
+


### PR DESCRIPTION
This removes the pirated functions `Colors.RGB(...)` and uses functionality provided by Colors.jl itself.

Related to https://github.com/WIAS-PDELib/GridVisualize.jl/issues/36