### PR TITLE
Fixed Slice-Plots of Tetrahedra with Plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Future Release 
+
+### Fixed
+
+- Reworked `tet_x_plane!()` to improve tetrahedron-plane-crosssection
+
 ## [3.0.0] - 2025-03-03
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -7,11 +7,13 @@ version = "3.0.0"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
 ColorSchemes = "3"
 Colors = "0.12, 0.13"
 DocStringExtensions = "0.8, 0.9"
+StaticArrays = "1.9.13"
 StaticArraysCore = "1.4"
 julia = "1.6"

--- a/src/GridVisualizeTools.jl
+++ b/src/GridVisualizeTools.jl
@@ -10,6 +10,7 @@ import ColorSchemes
 
 using DocStringExtensions: SIGNATURES, TYPEDEF, TYPEDSIGNATURES
 using StaticArraysCore: SVector
+using StaticArrays: @MArray
 
 include("colors.jl")
 export region_cmap, bregion_cmap, rgbtuple, rgbcolor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,21 @@ using Test, Documenter, GridVisualizeTools, ColorTypes, Colors
 DocMeta.setdocmeta!(GridVisualizeTools, :DocTestSetup, :(using GridVisualizeTools, ColorTypes, Colors); recursive = true)
 doctest(GridVisualizeTools)
 
+
+@testset "tet_x_plane" begin
+    #Testing amount of intersected edges of (x,y,z)-tetrahedron (0,0,0),(1,0,0),(1,1,0),(1,1,1) with plane x+y-1=0
+    @test GridVisualizeTools.tet_x_plane!(
+        [0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0; 0.0 0.0 1.0 1.0 0.0 0.0 1.0 1.0; 0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0],
+        Int32[1, 2, 4, 8],
+        [-1.0, 0.0, 1.0, 1.0],
+        [0, 0, 0, 0, 0, 0, 0, 1],
+        tol = 1.0e-12
+    ) == 3
+end
+
+
 if isdefined(Docs, :undocumented_names) # >=1.11
     @testset "UndocumentedNames" begin
         @test isempty(Docs.undocumented_names(GridVisualizeTools))


### PR DESCRIPTION
When using slice_plot to view the cross-section of a given grid with a given plane, the resulting images had "holes" or missing shapes. 
This was seemingly caused by a problem in tet_x_plane!() in marching.jl and should now be fixed.