### PR TITLE
Use MArrays for small data holders in marching_tetrahedra

### DIFF
--- a/src/marching.jl
+++ b/src/marching.jl
@@ -222,11 +222,10 @@ function marching_tetrahedra(
         @views push!(all_ixvalues, primevalues[iprime])
     end
 
-    planeq = zeros(4)
-    ixcoord = zeros(3, 6)
-    ixvalues = zeros(6)
-    cn = zeros(4)
-    node_indices = zeros(Int32, 4)
+    planeq = @MArray zeros(4)
+    ixcoord = @MArray zeros(3, 6)
+    ixvalues = @MArray zeros(6)
+    node_indices = @MArray zeros(Int32, 4)
 
     # Function to evaluate plane equation
     @inbounds @fastmath plane_equation(plane, coord) = coord[1] * plane[1] + coord[2] * plane[2] + coord[3] * plane[3] + plane[4]


### PR DESCRIPTION
This reduces the wall time.

demo:
```julia
using ExtendableGrids, GridVisualizeTools

grid = uniform_refine(grid_unitcube(Tetrahedron3D), 6)

coords = grid[Coordinates]
cellnodes = grid[CellNodes]
func = ones(size(cellnodes, 2))

@benchmark marching_tetrahedra(coords, cellnodes, func, [[1.,1.,1.,-1.]], [])
```

yields 

```
BenchmarkTools.Trial: 105 samples with 1 evaluation per sample.
 Range (min … max):  46.173 ms … 52.366 ms  ┊ GC (min … max): 0.00% … 2.72%
 Time  (median):     47.590 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   47.930 ms ±  1.352 ms  ┊ GC (mean ± σ):  0.60% ± 1.22%

       ██▂▂▄▄       ▂▂▂▂ ▆                                     
  █▆▄████████▆█▆▆▆█▄████▄██▁▁▄▁▄▄▆▁▁▁▄▄▁▆▄▆▁▁▆▁▄▁▄▁▄▁▁▄▁▁▁▁▁▄ ▄
  46.2 ms         Histogram: frequency by time          52 ms <

 Memory estimate: 5.89 MiB, allocs estimate: 84.
```
without `@MArray` and 
```
BenchmarkTools.Trial: 141 samples with 1 evaluation per sample.
 Range (min … max):  33.983 ms … 39.415 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     35.359 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   35.589 ms ±  1.086 ms  ┊ GC (mean ± σ):  0.82% ± 1.51%

       █▁▁▄▄▆  ▃▁▆     ▃     ▁▃    ▁                           
  ▆▆▆▆▆██████▇▇███▆▇▇▆▇█▆▇▆▄▇██▇▇▄▄█▇▄▇▆▄▁▁▄▆▁▁▄▄▁▆▄▆▄▁▁▁▁▄▁▄ ▄
  34 ms           Histogram: frequency by time        38.5 ms <

 Memory estimate: 5.89 MiB, allocs estimate: 80.
```
with `@MArray`.

This is reduces wall time by about  25%.

The `cn` array is not used, and therefore removed.
